### PR TITLE
Fixing Shupload DDoS Due To Lack Of Filenames Lengths Validation

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,5 +2,6 @@
   "Address": ":8088",
   "DatabaseLocation": "db",
   "EntryKeyRunes": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0"],
-  "EntryKeyLength": 8
+  "EntryKeyLength": 8,
+  "MaxFilenameLength": 100
 }

--- a/src/App.go
+++ b/src/App.go
@@ -43,6 +43,7 @@ func (a *App) Init() (err error) {
     EntryKeyLength: 8,
     Address: ":8088",
     DatabaseLocation: "db",
+    MaxFilenameLength: 100,
   }
 
   err = AppInstance.Config.Load("config.json")

--- a/src/AppConfig.go
+++ b/src/AppConfig.go
@@ -29,6 +29,7 @@ type AppConfig struct {
   EntryKeyLength int `json:"EntryKeyLength"`
   Address string `json:"Address"`
   DatabaseLocation string `json:"DatabaseLocation"`
+  MaxFilenameLength string `json:MaxFilenameLength`
 }
 
 func (a *AppConfig) Load(filename string) (err error) {

--- a/src/AppConfig.go
+++ b/src/AppConfig.go
@@ -29,7 +29,7 @@ type AppConfig struct {
   EntryKeyLength int `json:"EntryKeyLength"`
   Address string `json:"Address"`
   DatabaseLocation string `json:"DatabaseLocation"`
-  MaxFilenameLength string `json:MaxFilenameLength`
+  MaxFilenameLength int `json:MaxFilenameLength`
 }
 
 func (a *AppConfig) Load(filename string) (err error) {

--- a/src/DataBase_filestore.go
+++ b/src/DataBase_filestore.go
@@ -135,8 +135,8 @@ func (d *DataBase) Init() (err error) {
 func (d *DataBase) CreateEntry(r multipart.File, h *multipart.FileHeader) (entry DataBaseEntry, key string, err error) {
   key = d.GetKey()
   
-  if (len(h.Filename) > 100) {
-    return 
+  if (len(h.Filename) > AppInstance.Config.MaxFilenameLength) {
+    return
   }
   
   entry = DataBaseEntry{

--- a/src/DataBase_filestore.go
+++ b/src/DataBase_filestore.go
@@ -134,6 +134,11 @@ func (d *DataBase) Init() (err error) {
 
 func (d *DataBase) CreateEntry(r multipart.File, h *multipart.FileHeader) (entry DataBaseEntry, key string, err error) {
   key = d.GetKey()
+  
+  if (len(h.Filename) > 100) {
+    return 
+  }
+  
   entry = DataBaseEntry{
     CreationTime: time.Now(),
     Filename: h.Filename,


### PR DESCRIPTION
### 📊 Metadata *
- Lack Of Filenames Length Validation Leads To DDoS By Storing Huge Values In The DataBase.

#### Bounty URL: https://www.huntr.dev/bounties/1-other-shupload/

### ⚙️ Description *
- In Shupload, You're Storing The Original Filenames On The Database Without Validating It. And Since There's No Authentication Required. Remote Attackers Are Able To Insert Huge Values On The Database Then Interact With It And Requesting It From The Server Resulting In Both Client-Side/Server-Side DoS By Increasing The CPU Usage On The Server For The Server And On The Browser For The User.

- Attackers Are Able To Freeze The Next Shupload Run By Inserting Huge Values Into The Database. So When `./shupload` Is Running. It Will Take a Lot  Of Time Loading The Data From The Database Then Start. Until The Data Is Loaded The Program Won't Start. Multiple Users Doing The Same Action Can Perform a DDoS Attack On The Server.

### 💻 Technical Description *
- Lack Of Input Length Validation Resulting In DDoS In Furthur Communation.
- My Fix Was To Create a Length Validation On `h.Filename` To Check If It's Larger Than 100 Character. If It's Then Nothing Gonna Be Saved

```golang
if (len(h.Filename) > 100) {
  return
}
```

### 🐛 Proof of Concept (PoC) *
- Check The Screen Shot On The Bounty URL I Provided.

### 🔥 Proof of Fix (PoF) *
- Here's Screen Shot For an Image Example Uploaded With More Than 100 Character On The Filename. The Server Didn't Accept/Store It On The Database Due To The Fix I Added.

![Shupload-POF](https://user-images.githubusercontent.com/54229853/107858470-f0160480-6e3c-11eb-8deb-01ee2be2f641.png)


### 👍 User Acceptance Testing (UAT)
- Tested.

### 🔗 Relates to...
- https://github.com/418sec/huntr/pull/1897
