### PR TITLE
Fixing Shupload DoS Issue Due To Lack Of Uploaded Images Size Validation.

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,5 +3,6 @@
   "DatabaseLocation": "db",
   "EntryKeyRunes": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0"],
   "EntryKeyLength": 8,
-  "MaxFilenameLength": 100
+  "MaxFilenameLength": 100,
+  "MaxFileSize": 20000
 }

--- a/src/App.go
+++ b/src/App.go
@@ -44,6 +44,7 @@ func (a *App) Init() (err error) {
     Address: ":8088",
     DatabaseLocation: "db",
     MaxFilenameLength: 100,
+    MaxFileSize: 20000,
   }
 
   err = AppInstance.Config.Load("config.json")

--- a/src/AppConfig.go
+++ b/src/AppConfig.go
@@ -29,7 +29,8 @@ type AppConfig struct {
   EntryKeyLength int `json:"EntryKeyLength"`
   Address string `json:"Address"`
   DatabaseLocation string `json:"DatabaseLocation"`
-  MaxFilenameLength int `json:MaxFilenameLength`
+  MaxFilenameLength int `json:"MaxFilenameLength"`
+  MaxFileSize int `json:"MaxFileSize"`
 }
 
 func (a *AppConfig) Load(filename string) (err error) {

--- a/src/DataBase_filestore.go
+++ b/src/DataBase_filestore.go
@@ -56,6 +56,19 @@ func (fd *FileDriver) Write(key string, r io.ReadCloser) (err error) {
   if err != nil {
     return
   }
+  
+  info,err := os.Stat(path.Join(fd.root, key))
+  var kbLimit int64 = 1024
+  var fileSize int64 = info.Size()
+  kbSize := float64(fileSize) / float64(kbLimit)
+
+  if (int(kbSize) > AppInstance.Config.MaxFileSize) {
+    os.Remove(path.Join(fd.root, key))
+    if err != nil {
+      return
+    }
+  }
+  
   return
 }
 

--- a/src/DataBase_filestore.go
+++ b/src/DataBase_filestore.go
@@ -56,19 +56,6 @@ func (fd *FileDriver) Write(key string, r io.ReadCloser) (err error) {
   if err != nil {
     return
   }
-  
-  info,err := os.Stat(path.Join(fd.root, key))
-  var kbLimit int64 = 1024
-  var fileSize int64 = info.Size()
-  kbSize := float64(fileSize) / float64(kbLimit)
-
-  if (int(kbSize) > AppInstance.Config.MaxFileSize) {
-    os.Remove(path.Join(fd.root, key))
-    if err != nil {
-      return
-    }
-  }
-  
   return
 }
 
@@ -147,11 +134,19 @@ func (d *DataBase) Init() (err error) {
 
 func (d *DataBase) CreateEntry(r multipart.File, h *multipart.FileHeader) (entry DataBaseEntry, key string, err error) {
   key = d.GetKey()
-  
+
   if (len(h.Filename) > AppInstance.Config.MaxFilenameLength) {
     return
   }
-  
+
+  var kbLimit int64 = 1024
+  var fileSize int64 = h.Size
+  kbSize := float64(fileSize) / float64(kbLimit)
+
+  if (int(kbSize) > AppInstance.Config.MaxFileSize) {
+    return
+  }
+
   entry = DataBaseEntry{
     CreationTime: time.Now(),
     Filename: h.Filename,


### PR DESCRIPTION
### 📊 Metadata *
- DoS Is Possible On Shupload Due To Lack Of Image Sizes Validation.

#### Bounty URL:  https://www.huntr.dev/bounties/2-other-shupload/

### ⚙️ Description *
- On Shupload There's No Limits For The Image Size You're Storing. It Accepts Any Image With Any Value On It. That Allows Remote Attackers To Upload Large Images Into The Server And Fill-Up The Server Space Until It Stops Working Since No Space Will Be Left To Write Data On. That Can Create A Successful DoS Attack On The Clients Running Shupload. This Issue Has Been Fixed By Checking The File Size After Storing It. If It Does Exceeds The Limit On The AppConfig (In Kb) The Program Will Delete That File From The `db` Folder To Keep The Server Space.

### 💻 Technical Description *
- Lack Of Uploads Size Validation Leads To Server-Side Denial Of Service By Uploading Large Images Into The Server That Will Fill-Up The Server Space.

### 🐛 Proof of Concept (PoC) *
- There's No POC Included. You Can Test It From Your Side Using The Steps To Reproduce On The Bounty URL.

### 🔥 Proof of Fix (PoF) *
- Again, Try It Out With a Big Image That Exceeds The MaxFileSize Limit. And You Will Get That It Got Deleted.

### 🔗 Relates to...
- https://github.com/418sec/huntr/pull/1905
